### PR TITLE
Add admin deletion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ pip install -r requirements.txt
 BOT_TOKEN=YOUR_TELEGRAM_TOKEN
 ```
 
-3. Run the bot:
+3. Add Telegram usernames of admins to `admins.txt` (one per line). These users can delete events.
+
+4. Run the bot:
 
 ```bash
 python bot.py

--- a/admins.txt
+++ b/admins.txt
@@ -1,0 +1,1 @@
+adminuser

--- a/database.py
+++ b/database.py
@@ -45,3 +45,23 @@ def list_events(chat_id: int):
     rows = c.fetchall()
     conn.close()
     return rows
+
+
+def list_events_with_ids(chat_id: int):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "SELECT id, title, date, time, location FROM events WHERE chat_id=? ORDER BY date, time",
+        (chat_id,),
+    )
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+
+def delete_event(event_id: int):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute("DELETE FROM events WHERE id=?", (event_id,))
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- let admins delete events
- maintain admin list in `admins.txt`
- document admin setup in README

## Testing
- `python -m py_compile bot.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_684432ffcb088325a34bc82be1ec8d35