### PR TITLE
Add superadmin management and fix delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ BOT_TOKEN=YOUR_TELEGRAM_TOKEN
 ```
 
 3. Add Telegram usernames of admins to `admins.txt` (one per line). These users can delete events.
+   Users listed in `superadmins.txt` have extended permissions to manage the admin list.
 
 4. Run the bot:
 

--- a/superadmins.txt
+++ b/superadmins.txt
@@ -1,0 +1,1 @@
+superadmin


### PR DESCRIPTION
## Summary
- introduce `superadmins.txt` with super admin privileges
- reload roles from files via new `/refresh` command
- allow super admins to add or remove admins
- hide admin commands for non-admins and show superadmin commands separately
- limit callback handler pattern to fix delete button loading issue

## Testing
- `python -m py_compile bot.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_684435b9d0c083258c28155b8a4916c9