### PR TITLE
Add event application support

### DIFF
--- a/database.py
+++ b/database.py
@@ -20,6 +20,15 @@ def init_db():
     columns = [row[1] for row in c.fetchall()]
     if "location" not in columns:
         c.execute("ALTER TABLE events ADD COLUMN location TEXT")
+    # Table for event applications
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS event_applications (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id INTEGER,
+        username TEXT,
+        UNIQUE(event_id, username)
+    )"""
+    )
     conn.commit()
     conn.close()
 
@@ -63,5 +72,64 @@ def delete_event(event_id: int):
     conn = sqlite3.connect(DB_NAME)
     c = conn.cursor()
     c.execute("DELETE FROM events WHERE id=?", (event_id,))
+    c.execute("DELETE FROM event_applications WHERE event_id=?", (event_id,))
     conn.commit()
     conn.close()
+
+
+def apply_to_event(event_id: int, username: str):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "INSERT OR IGNORE INTO event_applications (event_id, username) VALUES (?, ?)",
+        (event_id, username),
+    )
+    conn.commit()
+    conn.close()
+
+
+def cancel_application(event_id: int, username: str):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "DELETE FROM event_applications WHERE event_id=? AND username=?",
+        (event_id, username),
+    )
+    conn.commit()
+    conn.close()
+
+
+def list_applicants(event_id: int) -> list[str]:
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "SELECT username FROM event_applications WHERE event_id=? ORDER BY username",
+        (event_id,),
+    )
+    rows = [r[0] for r in c.fetchall()]
+    conn.close()
+    return rows
+
+
+def is_applied(event_id: int, username: str) -> bool:
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "SELECT 1 FROM event_applications WHERE event_id=? AND username=?",
+        (event_id, username),
+    )
+    row = c.fetchone()
+    conn.close()
+    return row is not None
+
+
+def get_event(event_id: int):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute(
+        "SELECT id, chat_id, title, date, time, location FROM events WHERE id=?",
+        (event_id,),
+    )
+    row = c.fetchone()
+    conn.close()
+    return row


### PR DESCRIPTION
## Summary
- allow users to apply or cancel application for each event
- store applicants in new `event_applications` table
- show per-event list with buttons to apply or cancel

## Testing
- `python -m py_compile bot.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_684439a2a89083258847528d07902e6b